### PR TITLE
Fix requisites for user state

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -39,12 +39,12 @@ include:
     - groups:
         - {{ name }}
       {% for group in user.get('groups', []) %}
-        - {{ group }}_group
+        - {{ group }}
       {% endfor %}
     - require:
-        - group: {{ name }}_user
+        - group: {{ name }}
       {% for group in user.get('groups', []) %}
-        - group: {{ group }}_group
+        - group: {{ group }}
       {% endfor %}
 
 user_keydir_{{ name }}:


### PR DESCRIPTION
group requisites were wrong. They required {{ group }}_group, while {{ group }} was the actually added group.

((This is my first pull request. I hope it ends up where it needs to be. Please tell me if I did anything wrong))
