### PR TITLE
Fixed user default shell source

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -28,7 +28,7 @@ include:
   user.present:
     - name: {{ name }}
     - home: {{ home }}
-    - shell: {{ pillar.get('shell', '/bin/bash') }}
+    - shell: {{ user.get('shell', '/bin/bash') }}
     {% if 'uid' in user -%}
     - uid: {{ user['uid'] }}
     {% endif %}


### PR DESCRIPTION
Pulling 'shell' from pillar globally makes no sense, probably a mistake; pulling it from user instead.
