### PR TITLE
For some reason pillar.get does not return [], but None

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -125,7 +125,11 @@ sudoer-{{ name }}:
 
 {% endfor %}
 
-{% for user in pillar.get('absent_users', []) %}
+{% set users =  pillar.get('absent_users', []) %}
+{% if users == None %}
+{% set users = [] %}
+{% endif %}
+{% for user in users %}
 {{ user }}:
   user.absent
 /etc/sudoers.d/{{ user }}:


### PR DESCRIPTION
If absent_users is in the pillar file and contains now users, pillar.get returns a None type.  This causes the template to fail to render.  Added a check to replace None with [] to fix this issue.