### PR TITLE
Fix Undefined jinja variable error with Salt 0.17.1

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -25,7 +25,9 @@ include:
       - group: {{ name }}
   group.present:
     - name: {{ name }}
+    {% if 'uid' in user -%}
     - gid: {{ user['uid'] }}
+    {% endif %}
   user.present:
     - name: {{ name }}
     - home: {{ home }}


### PR DESCRIPTION
Ran into an error with Salt version 0.17.1:
Rendering SLS users failed, render error: Undefined jinja variable; line 32

After finding https://github.com/saltstack/salt/issues/8245, and working on
line 32, I surmised that line 28 might be the actual cause of the issue.

I just added a quick check to see if uid exists in user, just as the user uid
line does.
