### PR TITLE
SLS no longer fails for multiple groups

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -14,7 +14,7 @@ include:
 {%- endif %}
 
 {% for group in user.get('groups', []) %}
-{{ group }}_group:
+{{ name }}_{{ group }}_group:
   group:
     - name: {{ group }}
     - present
@@ -87,7 +87,7 @@ user_{{ name }}_private_key:
     - require:
       - user: {{ name }}_user
       {% for group in user.get('groups', []) %}
-      - group: {{ group }}_group
+      - group: {{ name }}_{{ group }}_group
       {% endfor %}
 user_{{ name }}_public_key:
   file.managed:
@@ -99,7 +99,7 @@ user_{{ name }}_public_key:
     - require:
       - user: {{ name }}_user
       {% for group in user.get('groups', []) %}
-      - group: {{ group }}_group
+      - group: {{ name }}_{{ group }}_group
       {% endfor %}
   {% endif %}
 


### PR DESCRIPTION
Because the group-present state was inside foreach, the resulting YAML contained duplicate groupname_group IDs. Prepending the username fixes the issue. More elegant solution would be to somehow get all the groups first and create them outside the loop (thus reducing the number of resulting state IDs from `n_users * n_groups` to `n_groups`). But I don't know how to do it and this is good enough. 
