### PR TITLE
Change .ssh directory permissions to 700

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -68,7 +68,7 @@ user_keydir_{{ name }}:
     - user: {{ name }}
     - group: {{ user_group }}
     - makedirs: True
-    - mode: 744
+    - mode: 700
     - require:
       - user: {{ name }}
       - group: {{ user_group }}


### PR DESCRIPTION
The ssh(1) manpage recommends to set permissions for the $HOME/.ssh/ directory to 700:

```
~/.ssh/
 This directory is the default location for all user-specific configuration and authentication informa‐
 tion.  There is no general requirement to keep the entire contents of this directory secret, but the
 recommended permissions are read/write/execute for the user, and not accessible by others.
```

I consider it a good idea to follow this recommendation as it makes it just a little bit more secure.
