### PR TITLE
Fix ssh_auth.names in example pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -22,7 +22,7 @@ users:
       privkey: PRIVATEKEY
       pubkey: PUBLICKEY
     ssh_auth:
-      - ssh-rsa: PUBLICKEYKEYKEY
+      - PUBLICKEY
 
 absent_users:
   - donald


### PR DESCRIPTION
The previous example in pillar.example could cause users to use something like:

```
users:
  auser:
    ...
    ssh_auth:
      - ssh-rsa: AAAAB3N.....
```

But the expected value is simply the "name" as discussed in http://docs.saltstack.com/ref/states/all/salt.states.ssh_auth.html

I believe that the given example makes it a bit more obvious which data to use in the pillar and should, preferably, even be accompanied by a link to the aforementioned ssh_auth documentation in the README.
