### PR TITLE
Changed 'contents' to 'contents_pillar' to correctly parse newlines for private/public SSH keys.

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -84,7 +84,7 @@ user_{{ name }}_private_key:
     - user: {{ name }}
     - group: {{ user_group }}
     - mode: 600
-    - contents: {{ user['ssh_keys']['privkey'] }} 
+    - contents_pillar: users:{{ name }}:ssh_keys:privkey
     - require:
       - user: {{ name }}_user
       {% for group in user.get('groups', []) %}
@@ -96,7 +96,7 @@ user_{{ name }}_public_key:
     - user: {{ name }}
     - group: {{ user_group }}
     - mode: 644
-    - contents: {{ user['ssh_keys']['pubkey'] }} 
+    - contents_pillar: users:{{ name }}:ssh_keys:privkey
     - require:
       - user: {{ name }}_user
       {% for group in user.get('groups', []) %}


### PR DESCRIPTION
this pillar file will generate an error:

```
--- 
users: 
  foo: 
    name: foo
    shell: /bin/false
    ssh_keys: 
      privkey: |
        -----BEGIN RSA PRIVATE KEY-----
        foo
        -----END RSA PRIVATE KEY-----
      pubkey: "ssh-rsa somekey foo@bar.com"
```

error:

```
    Data failed to compile:
----------
    Rendering SLS "base:users" failed: Unknown yaml render error; line 52

---
[...]
    - user: foo
    - group: foo
    - mode: 600
    - contents: -----BEGIN RSA PRIVATE KEY-----
foo <======================
```

The solution is to use contents_pillar (0.17.0+).
