### PR TITLE
Check for sudo_rules before text.append state.

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -125,15 +125,17 @@ sudoer-{{ name }}:
     - user: root
     - group: root
     - mode: '0440'
+{% if 'sudo_rules' in user %}
 /etc/sudoers.d/{{ name }}:
   file.append:
-  - text:
-    {% for rule in user.get('sudo_rules', []) %}
-    - {{ rule }}
-    {% endfor %}
-  - require:
-    - file: sudoer-defaults
-    - file: sudoer-{{ name }}
+    - text:
+      {% for rule in user['sudo_rules'] %}
+      - "{{ name }} {{ rule }}"
+      {% endfor %}
+    - require:
+      - file: sudoer-defaults
+      - file: sudoer-{{ name }}
+{% endif %}
 {% else %}
 /etc/sudoers.d/{{ name }}:
   file.absent:


### PR DESCRIPTION
Since ebe5198f, if a user's pillar dict didn't contain sudo_rules, a broken file.append state would be rendered (since some text is required). With this patch, the file is still created/managed by the previous state, but will be empty by default if created fresh. This seems a more sensible default than assuming a default sudoer policy.

Further, since the first word on each rule line should be the user's name, that is now assumed.
