### PR TITLE
New format of handling user.absent, supporting additional parameters

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,10 +1,9 @@
 users:
-## Minimal required pillar values
+  ## Minimal required pillar values
   auser:
-    groups:
-      - admin
+    fullname: A User
 
-## Full list of pillar values
+  ## Full list of pillar values
   buser:
     fullname: B User
     home: /custom/buser
@@ -25,6 +24,14 @@ users:
     ssh_auth:
       - PUBLICKEY
 
+  ## Absent user
+  cuser:
+    absent: True
+    purge: True
+    force: True
+
+
+## Old syntax of absent_users still supported
 absent_users:
   - donald
   - bad_guy


### PR DESCRIPTION
My use case was to remove a user **including her home directory**. The original users-formula did not provide support for additional parameters of "user.absent" ("purge" and "force"). Removing a homedir can obviously be achieved some other way, however I wanted this to happen automagically.

This patch adds support for three additional pillar values: "absent", "purge" and "force". The main _for_ loop excludes users in which "absent" in present (pun intended :) and does the usual work, while the additional _for_ loop goes only through the ones with "absent" and makes use of parameters.

I've provided new examples in the pillar.example file:

```
users:
  jenny:
    absent: True
    purge: True
    force: True
```

I also left support for "absent_users" syntax for backwards compatibility:

```
absent_users:
  - donald
  - bad_guy
```

I'm hoping you will find this modification useful. Thanks.
