### PR TITLE
Overwrite a sudoer file rather than append to fix #21

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -141,11 +141,11 @@ sudoer-{{ name }}:
 {% endfor %}
 
 /etc/sudoers.d/{{ name }}:
-  file.append:
-    - text:
-      {% for rule in user['sudo_rules'] %}
-      - "{{ name }} {{ rule }}"
-      {% endfor %}
+  file.managed:
+    - contents: |
+      {%- for rule in user['sudo_rules'] %}
+        {{ name }} {{ rule }}
+      {%- endfor %}
     - require:
       - file: sudoer-defaults
       - file: sudoer-{{ name }}


### PR DESCRIPTION
Don't append to a user's `sudoers` file, overwrite it instead so the privileges will exactly match the pillar.  Fix for #21.
