### PR TITLE
Specify bash shell when validating sudo snippet

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -135,6 +135,7 @@ sudoer-{{ name }}:
 "validate {{ name }} sudo rule {{ loop.index0 }} {{ name }} {{ rule }}":
   cmd.run:
     - name: 'visudo -cf - <<<"$rule"'
+    - shell: /bin/bash
     - env:
       # Specify the rule via an env var to avoid shell quoting issues.
       - rule: "{{ name }} {{ rule }}"


### PR DESCRIPTION
Since we are using bash specific features and sometimes you can end up getting /bin/sh - see https://github.com/saltstack-formulas/users-formula/pull/30#issuecomment-44224106
