### PR TITLE
Templatize the authorized keys file to support 'clearing' items

### DIFF
--- a/users/files/authorized_keys.jinja
+++ b/users/files/authorized_keys.jinja
@@ -1,0 +1,5 @@
+{% for name, user in pillar.get('users', {}).items() if user.absent is not defined or not user.absent -%}
+{% for auth in user['ssh_auth'] -%}
+{{ auth }}
+{% endfor -%}
+{% endfor -%}

--- a/users/init.sls
+++ b/users/init.sls
@@ -32,39 +32,39 @@
       - group: {{ user_group }}
   group.present:
     - name: {{ user_group }}
-    {%- if 'prime_group' in user and 'gid' in user['prime_group'] %}
+{%- if 'prime_group' in user and 'gid' in user['prime_group'] %}
     - gid: {{ user['prime_group']['gid'] }}
-    {%- elif 'uid' in user %}
+{%- elif 'uid' in user %}
     - gid: {{ user['uid'] }}
-    {%- endif %}
+{%- endif %}
   user.present:
     - name: {{ name }}
     - home: {{ home }}
     - shell: {{ user.get('shell', '/bin/bash') }}
-    {% if 'uid' in user -%}
+{% if 'uid' in user -%}
     - uid: {{ user['uid'] }}
-    {% endif -%}
-    {% if 'password' in user -%}
+{% endif -%}
+{% if 'password' in user -%}
     - password: {{ user['password'] }}
-    {% endif -%}
-    {% if 'prime_group' in user and 'gid' in user['prime_group'] -%}
+{% endif -%}
+{% if 'prime_group' in user and 'gid' in user['prime_group'] -%}
     - gid: {{ user['prime_group']['gid'] }}
-    {% else -%}
+{% else -%}
     - gid_from_name: True
-    {% endif -%}
-    {% if 'fullname' in user %}
+{% endif -%}
+{% if 'fullname' in user %}
     - fullname: {{ user['fullname'] }}
-    {% endif -%}
+{% endif -%}
     - groups:
       - {{ user_group }}
-      {% for group in user.get('groups', []) -%}
+{% for group in user.get('groups', []) -%}
       - {{ group }}
-      {% endfor %}
+{% endfor %}
     - require:
       - group: {{ user_group }}
-      {% for group in user.get('groups', []) -%}
+{% for group in user.get('groups', []) -%}
       - group: {{ group }}
-      {% endfor %}
+{% endfor %}
 
 user_keydir_{{ name }}:
   file.directory:
@@ -76,12 +76,12 @@ user_keydir_{{ name }}:
     - require:
       - user: {{ name }}
       - group: {{ user_group }}
-      {%- for group in user.get('groups', []) %}
+{%- for group in user.get('groups', []) %}
       - group: {{ group }}
-      {%- endfor %}
+{%- endfor %}
 
-  {% if 'ssh_keys' in user %}
-  {% set key_type = 'id_' + user.get('ssh_key_type', 'rsa') %}
+{% if 'ssh_keys' in user %}
+{% set key_type = 'id_' + user.get('ssh_key_type', 'rsa') %}
 user_{{ name }}_private_key:
   file.managed:
     - name: {{ user.get('home', '/home/{0}'.format(name)) }}/.ssh/{{ key_type }}
@@ -92,9 +92,9 @@ user_{{ name }}_private_key:
     - contents_pillar: users:{{ name }}:ssh_keys:privkey
     - require:
       - user: {{ name }}_user
-      {% for group in user.get('groups', []) %}
+{% for group in user.get('groups', []) %}
       - group: {{ name }}_{{ group }}_group
-      {% endfor %}
+{% endfor %}
 user_{{ name }}_public_key:
   file.managed:
     - name: {{ user.get('home', '/home/{0}'.format(name)) }}/.ssh/{{ key_type }}.pub
@@ -105,22 +105,20 @@ user_{{ name }}_public_key:
     - contents_pillar: users:{{ name }}:ssh_keys:pubkey
     - require:
       - user: {{ name }}_user
-      {% for group in user.get('groups', []) %}
+{% for group in user.get('groups', []) %}
       - group: {{ name }}_{{ group }}_group
-      {% endfor %}
-  {% endif %}
-
+{% endfor %}
+{% endif %}
 
 {% if 'ssh_auth' in user %}
-{% for auth in user['ssh_auth'] %}
-ssh_auth_{{ name }}_{{ loop.index0 }}:
-  ssh_auth.present:
+user_{{ name }}_authorized_keys:
+  file.managed:
+    - name: /home/{{ name }}/.ssh/authorized_keys
+    - source: salt://users/files/authorized_keys.jinja
     - user: {{ name }}
-    - name: {{ auth }}
-    - require:
-        - file: {{ name }}_user
-        - user: {{ name }}_user
-{% endfor %}
+    - group: {{ name }}
+    - mode: 644
+    - template: jinja
 {% endif %}
 
 {% if 'ssh_auth.absent' in user %}

--- a/users/map.jinja
+++ b/users/map.jinja
@@ -1,7 +1,7 @@
 # vim: sts=2 ts=2 sw=2 et ai
 {% set users = salt['grains.filter_by']({
   'Debian': {
-    'sudoers_dir': '/etc/sudoers.d/',
+    'sudoers_dir': '/etc/sudoers.d',
     'sudoers_file': '/etc/sudoers',
     'root_group': 'root',
     'visudo_shell': '/bin/bash',


### PR DESCRIPTION
This change modifies how the authorized keys file is handled as currently there is no way to 'wipe' keys from the file due to the way ssh_auth.present works. This makes the authorized keys file a managed file, and then drops the user's key in. I don't know if this is something that we do want to merge, and it should probably be reviewed and discussed, but I feel as though it does allow greater control.
