### PR TITLE
modified visudo to only report change in salt when there is an error. also add option to remove keys from ssh_auth

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -24,6 +24,8 @@ users:
       pubkey: PUBLICKEY
     ssh_auth:
       - PUBLICKEY
+    ssh_auth.absent:
+      - PUBLICKEY_TO_BE_REMOVED
 
   ## Absent user
   cuser:

--- a/users/init.sls
+++ b/users/init.sls
@@ -123,6 +123,17 @@ ssh_auth_{{ name }}_{{ loop.index0 }}:
 {% endfor %}
 {% endif %}
 
+{% if 'ssh_auth.absent' in user %}
+{% for auth in user['ssh_auth.absent'] %}
+ssh_auth_delete_{{ name }}_{{ loop.index0 }}:
+  ssh_auth.absent:
+    - user: {{ name }}
+    - name: {{ auth }}
+    - require:
+        - file: {{ name }}_user
+        - user: {{ name }}_user
+{% endfor %}
+{% endif %}
 
 {% if 'sudouser' in user and user['sudouser'] %}
 {% if not used_sudo %}


### PR DESCRIPTION
Every run of visudo resulted in a change in salt. To prevent this, I added stateful option to it and only give an (invalid json) output, if the syntax of the sudoers lines are wrong. Salt will result in an error then. Otherwise, nothing is returned, so no change for salt!

Added also option to remove keys
