### PR TITLE
Fix issue with bash binary location in FreeBSD

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -40,7 +40,7 @@
   user.present:
     - name: {{ name }}
     - home: {{ home }}
-    - shell: {{ user.get('shell', '/bin/bash') }}
+    - shell: {{ users.get('visudo_shell', '/bin/bash') }}
     {% if 'uid' in user -%}
     - uid: {{ user['uid'] }}
     {% endif -%}


### PR DESCRIPTION
Hello! 
I found a problem. When using users-formula and user's shell doesn't define in pillar, default bash binary location for FreeBSD is set to '/bin/bash'. But in fact it's location is '/usr/local/bin/bash'. This paths is defined in variable 'visudo_shell' in map.jinja, and I used it.
Sorry for my english.
