### PR TITLE
Add 'createhome' option for 'user.present' state

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -8,6 +8,7 @@ users:
     fullname: B User
     password: $6$w.............
     home: /custom/buser
+    createhome: True
     sudouser: True
     sudo_rules: 
       - ALL=(root) /usr/bin/find

--- a/users/init.sls
+++ b/users/init.sls
@@ -55,6 +55,9 @@
     {% if 'fullname' in user %}
     - fullname: {{ user['fullname'] }}
     {% endif -%}
+    {% if not user.get('createhome', True) %}
+    - createhome: False
+    {% endif %}
     - groups:
       - {{ user_group }}
       {% for group in user.get('groups', []) -%}


### PR DESCRIPTION
The `user.present` state takes a `createhome` option that defaults to `True`.

This commit passes `- createhome: False` to the state if `pillar.get('createhome', True)` is falsey.

Also adds the option to the example pillar.
