### PR TITLE
Add options for remove_groups and default to false

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -58,7 +58,9 @@
     {% if not user.get('createhome', True) %}
     - createhome: False
     {% endif %}
-    {% if not user.get('remove_groups', True) %}
+    {% if user.get('remove_groups', True) %}
+    - remove_groups: True
+    {% else %}
     - remove_groups: False
     {% endif %}
     - groups:


### PR DESCRIPTION
By default, Salt will remove any groups not listed, so a users groups matches exactly the list you pass.  This was added here:

https://github.com/saltstack/salt/issues/2142

This has been causing issues for many people, as the remove_groups option was a silent change.  In the 2014.7 release this is changing, and remove_groups will default to false:
https://github.com/saltstack/salt/issues/13276

I'm going with false by default, as it's our use case and it will soon be the default.  If people believe this module should default to true and remove groups not listed, I think that's open for discussion, but we should at least add the option.
