### PR TITLE
Allow '!' prefix in password for disabled\locked accounts.

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -45,7 +45,7 @@
     - uid: {{ user['uid'] }}
     {% endif -%}
     {% if 'password' in user -%}
-    - password: {{ user['password'] }}
+    - password: '{{ user['password'] }}'
     {% endif -%}
     {% if 'prime_group' in user and 'gid' in user['prime_group'] -%}
     - gid: {{ user['prime_group']['gid'] }}


### PR DESCRIPTION
Without single\double quotes around the user password, PyYAML interprets the ! as a tag variable, rather than the first character of the password string.

This means passwords cannot be set to '!' (to disable log in) or '!$6$....' (to lock accounts).
