### PR TITLE
Added option to source ssh public keys from files.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -32,6 +32,11 @@ users:
     # with the given keys
     ssh_auth_file:
       - PUBLICKEY
+    # If you prefer to keep public keys as files rather
+    # than inline in pillar, this works.
+    ssh_auth_sources:
+      - salt://keys/buser.id_rsa.pub
+
     google_auth:
       ssh: |
         SOMEGAUTHHASHVAL

--- a/users/init.sls
+++ b/users/init.sls
@@ -166,6 +166,18 @@ ssh_auth_{{ name }}_{{ loop.index0 }}:
 {% endfor %}
 {% endif %}
 
+{% if 'ssh_auth_sources' in user %}
+{% for pubkey_file in user['ssh_auth_sources'] %}
+ssh_auth_source_{{ name }}_{{ loop.index0 }}:
+  ssh_auth.present:
+    - user: {{ name }}
+    - source: {{ pubkey_file }}
+    - require:
+        - file: {{ name }}_user
+        - user: {{ name }}_user
+{% endfor %}
+{% endif %}
+
 {% if 'ssh_auth.absent' in user %}
 {% for auth in user['ssh_auth.absent'] %}
 ssh_auth_delete_{{ name }}_{{ loop.index0 }}:


### PR DESCRIPTION
If you name your keys after your users, I think this can make the users pillar very concise. e.g. something like:

```
{%- load_yaml as userlist %}
- user1
- user2
- ...
{%- endload %}

users:
{%- for user in userlist %}
  {{ user }}:
    ssh_auth_sources:
      - salt://keys/{{ user }}.id_rsa.pub
{%- endfor %}
```