### PR TITLE
Add the ability to pull ssh keys from a different pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -23,9 +23,15 @@ users:
     groups:
       - users
     ssh_key_type: rsa
+    # You can inline the private keys ...
     ssh_keys:
       privkey: PRIVATEKEY
       pubkey: PUBLICKEY
+    # ... or you can pull them from a different pillar,
+    # for example one called "ssh_keys":
+    ssh_keys_pillar:
+      id_rsa: "ssh_keys"
+      another_key_pair: "ssh_keys"
     ssh_auth:
       - PUBLICKEY
     ssh_auth.absent:


### PR DESCRIPTION
If you like to keep your ssh keys in a separate pillar, because, for example you need to deploy them to the root user as well, you can now use this formula without repeating yourself. 

I have added the ability to pull ssh keys from a different pillar that could for example, look like this:

```yaml
ssh_keys:
  id_rsa:
    privkey: |
      -----BEGIN RSA PRIVATE KEY-----
      MIIEowIBAAKCAQEAoQiwO3JhBquPAalQF9qP1lLZNXVjYMIswrMe2HcWUVBgh+vY
      U7sCwx/dH6+VvNwmCoqmNnP+8gTPKGl1vgAObJAnMT623dMXjVKwnEagZPRJIxDy
      B/HaAre9euNiY3LvIzBTWRSeMfT+rWvIKVBpvwlgGrfgz70m0pqxu+UyFbAGLin+
      GpxzZAMaFpZw4sSbIlRuissXZj/sHpQb8p9M5IeO4Z3rjkCP1cxI
      -----END RSA PRIVATE KEY-----
    pubkey: |
      ssh-rsa MIIEowIBAAKCAQEAoQiwO3JhBquPAalQF9qP1lLZNXVjYMIswrMe2H....
```