### PR TITLE
Added bashrc extension to users-formula

### DIFF
--- a/users/bashrc.sls
+++ b/users/bashrc.sls
@@ -1,0 +1,26 @@
+{% from "users/map.jinja" import users with context %}
+include:
+  - users
+
+extend:
+{% for name, user in pillar.get('users', {}).items() if user.absent is not defined or not user.absent %}
+{%- if user == None -%}
+{%- set user = {} -%}
+{%- endif -%}
+{%- set home = user.get('home', "/home/%s" % name) -%}
+
+{%- if 'prime_group' in user and 'name' in user['prime_group'] %}
+{%- set user_group = user.prime_group.name -%}
+{%- else -%}
+{%- set user_group = name -%}
+{%- endif %}
+  users_{{ name }}_user:
+    file.managed:
+      - name: {{ home }}/.bashrc
+      - owner: {{ name }}
+      - group: {{ user_group }}
+      - mode: 644
+      - sources: 
+        - salt://users/files/bashrc/{{ name }}/bashrc
+        - salt://users/files/bashrc/bashrc
+{% endfor %}

--- a/users/bashrc.sls
+++ b/users/bashrc.sls
@@ -20,7 +20,7 @@ extend:
       - owner: {{ name }}
       - group: {{ user_group }}
       - mode: 644
-      - sources: 
+      - source: 
         - salt://users/files/bashrc/{{ name }}/bashrc
         - salt://users/files/bashrc/bashrc
 {% endfor %}

--- a/users/files/bashrc/bashrc
+++ b/users/files/bashrc/bashrc
@@ -1,0 +1,9 @@
+#
+# ~/.bashrc
+#
+#
+# If not running interactively, don't do anything
+[[ $- != *i* ]] && return
+
+alias ls='ls --color=auto'
+PS1='[\u@\h \W]\$ '


### PR DESCRIPTION
This will ensure a given bashrc file in a users home dir.
Default it will search for a bashrc in salt://users/files/bashrc/{{ username }}/bashrc
If no file is found it will install the default from
salt://users/files/bashrc/bashrc