### PR TITLE
the user's .ssh directory should be created if ssh_auth_file is supplied

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -102,7 +102,7 @@ users_{{ name }}_user:
       {% endfor %}
 
 
-  {% if 'ssh_keys' in user or 'ssh_auth' in user or 'ssh_auth.absent' in user %}
+  {% if 'ssh_keys' in user or 'ssh_auth' in user or 'ssh_auth_file' in user or 'ssh_auth.absent' in user %}
 user_keydir_{{ name }}:
   file.directory:
     - name: {{ user.get('home', '/home/{0}'.format(name)) }}/.ssh


### PR DESCRIPTION
When using the ssh_auth_file pillar option to create an authorized_hosts file, the .ssh directory was not being created causing a highstate to fail. This will create the user's .ssh directory if the ssh_auth_file option was set.