### PR TITLE
Don't add sudo group by default.

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -39,9 +39,11 @@ include:
 
 {% for group in user.get('groups', []) %}
 users_{{ name }}_{{ group }}_group:
-  group:
+  group.present:
     - name: {{ group }}
-    - present
+    {% if group == 'sudo' %}
+    - system: True
+    {% endif %}
 {% endfor %}
 
 users_{{ name }}_user:

--- a/users/sudo.sls
+++ b/users/sudo.sls
@@ -6,16 +6,10 @@ users_bash-package:
   pkg.installed:
     - name: {{ users.bash_package }}
 
-users_sudo-group:
-  group.present:
-    - name: sudo
-    - system: True
-
 users_sudo-package:
   pkg.installed:
     - name: {{ users.sudo_package }}
     - require:
-      - group: users_sudo-group
       - file: {{ users.sudoers_dir }} 
 
 users_{{ users.sudoers_dir }}:


### PR DESCRIPTION
This formula doesn't really require the sudo group (unless
there are actually users in that group). Moreover, on FreeBSD
the 'admin' group would be wheel and not sudo.