### PR TITLE
Added ability to specify room number, home phone, and work phone

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -10,6 +10,9 @@ users:
     enforce_password: True
     home: /custom/buser
     createhome: True
+    roomnumber: "A-1"
+    workphone: "(555) 555-5555"
+    homephone: "(555) 555-5551"
     manage_vimrc: False
     manage_bashrc: False
     manage_profile: False

--- a/users/init.sls
+++ b/users/init.sls
@@ -95,6 +95,15 @@ users_{{ name }}_user:
     {% if 'fullname' in user %}
     - fullname: {{ user['fullname'] }}
     {% endif -%}
+    {% if 'roomnumber' in user %}
+    - roomnumber: {{ user['roomnumber'] }}
+    {% endif %}
+    {% if 'workphone' in user %}
+    - workphone: {{ user['workphone'] }}
+    {% endif %}
+    {% if 'homephone' in user %}
+    - homephone: {{ user['workphone'] }}
+    {% endif %}
     {% if not user.get('createhome', True) %}
     - createhome: False
     {% endif %}


### PR DESCRIPTION
Added ability to specify room number, home phone, and work phone as per https://docs.saltstack.com/en/develop/ref/states/all/salt.states.user.html.  This gives the user the ability to avoid having "fullname,,," in GECOS field in /etc/passwd and allows to fully populate the GECOS field.