### PR TITLE
Fix minor bug for ssh known_hosts management with salt >= 2015.5.5.

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -301,6 +301,9 @@ users_ssh_known_hosts_{{ name }}_{{ loop.index0 }}:
     {% if 'enc' in host %}
     - enc: {{ host['enc'] }}
     {% endif -%}
+    {% if 'hash_hostname' in host %}
+    - hash_hostname: {{ host['hash_hostname'] }}
+    {% endif -%}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
This version complains that "argument port can not be used in
conjunction with argument hash_hostname", so add hash_hostname
to the fields we handle in the formula so we can override it
if needed.