### PR TITLE
Default path for home folder in user_files.sls if home omitted in pillar.

### DIFF
--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -28,7 +28,7 @@ include:
 {%- if not skip_user %}
 users_userfiles_{{ username }}_recursive:
   file.recurse:
-    - name: {{ user.home }}
+    - name: {{ salt['pillar.get']( username ~ 'user:home', '/home/' ~ username )}}
     - source: {{ file_source }}
     - user: {{ username }}
     - group: {{ user_group }}


### PR DESCRIPTION
Fix for #99 
Rendering SLS 'base:users.user_files' failed: Jinja variable 'dict object' has no attribute 'home'