### PR TITLE
Mitigate Salt issue #29004, fixes "expire" on *BSD

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -113,7 +113,17 @@ users_{{ name }}_user:
     - createhome: False
     {% endif %}
     {% if 'expire' in user -%}
+        {% if grains['kernel'].endswith('BSD') and
+            user['expire'] < 157766400 %}
+        {# 157762800s since epoch equals 01 Jan 1975 00:00:00 UTC #}
+    - expire: {{ user['expire'] * 86400 }}
+        {% elif grains['kernel'] == 'Linux' and
+            user['expire'] > 84006 %}
+        {# 2932896 days since epoch equals 9999-12-31 #}
+    - expire: {{ (user['expire'] / 86400) | int}}
+        {% else %}
     - expire: {{ user['expire'] }}
+        {% endif %}
     {% endif -%}
     - remove_groups: {{ user.get('remove_groups', 'False') }}
     - groups:


### PR DESCRIPTION
(See [Salt issue #29004](https://github.com/saltstack/salt/issues/29004))

Unreasonable values for 'expire' (after 9999-12-31
on Linux, before 1975-01-01 on *BSD) get divided
by 86400 (number of seconds in a day) when too big
or multiplied by 86400 when too small.

Tested on CentOS 6 (Salt 2015.5.5) and FreeBSD 10.2
(Salt 2015.8.0) with following values:

  - 24854 (2038-01-18 in days since epoch)
  - 157766400 (1975-01-01 00:00:00 UTC in seconds since epoch)
  - 3313526400 (2075-01-01 00:00:00 UTC in seconds since epoch)
  - 16000 (2013-10-22 in days since epoch)
  - 18000 (2019-04-14 in days since epoch)

(Sponsored by av.tu-berlin.de and fokus.fraunhofer.de)