### PR TITLE
Use the primary group for the user when creating authorized_keys

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -195,7 +195,7 @@ users_authorized_keys_{{ name }}:
   file.managed:
     - name: {{ home }}/.ssh/authorized_keys
     - user: {{ name }}
-    - group: {{ name }}
+    - group: {{ user_group }}
     - mode: 600
 {% if 'ssh_auth_file' in user %}
     - contents: |


### PR DESCRIPTION
If a primary group is set on the user, and a authorized_keys is provied in ssh_auth_file, the formula fails. This solves that by using the user_group set earlier in the formula