### PR TITLE
User files state without defined home directory

### DIFF
--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -7,6 +7,7 @@ include:
 {%- for username, user in salt['pillar.get']('users', {}).items() if (user.absent is not defined or not user.absent) -%}
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
+{%- set home = user.get('home', "/home/%s" % username) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -28,7 +29,7 @@ include:
 {%- if not skip_user %}
 users_userfiles_{{ username }}_recursive:
   file.recurse:
-    - name: {{ user.home }}
+    - name: {{ home }}
     - source: {{ file_source }}
     - user: {{ username }}
     - group: {{ user_group }}


### PR DESCRIPTION
Without `home` parameter in pillar file the following error occurs during highstate process:

> Rendering SLS 'base:users.user_files' failed: Jinja variable 'collections.OrderedDict object' has no attribute 'home'