### PR TITLE
Default path for home folder in user_files.sls if home omitted in pillar [fixed style].

### DIFF
--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -7,6 +7,7 @@ include:
 {%- for username, user in salt['pillar.get']('users', {}).items() if (user.absent is not defined or not user.absent) -%}
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
+{%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), '/home/' ~ username ) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -28,7 +29,7 @@ include:
 {%- if not skip_user %}
 users_userfiles_{{ username }}_recursive:
   file.recurse:
-    - name: {{ salt['pillar.get']( username ~ 'user:home', '/home/' ~ username )}}
+    - name: {{ user_home }}
     - source: {{ file_source }}
     - user: {{ username }}
     - group: {{ user_group }}

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -28,7 +28,7 @@ include:
 {%- if not skip_user %}
 users_userfiles_{{ username }}_recursive:
   file.recurse:
-    - name: {{ user.home }}
+    - name: {{ salt['pillar.get']( username ~ 'user:home', '/home/' ~ username )}}
     - source: {{ file_source }}
     - user: {{ username }}
     - group: {{ user_group }}


### PR DESCRIPTION
Fix for #99 with style/pattern already used in formula.
Currently if 'home' option omitted in pillar you will get error:
`Rendering SLS 'base:users.user_files' failed: Jinja variable 'dict object' has no attribute 'home'`
With this fix you will get `/home/%username%` as default path for user home folder. It doesn't cover all possible situations as @0xf10e pointed there [1](https://github.com/saltstack-formulas/users-formula/pull/100#issuecomment-156035096) [2](https://github.com/saltstack-formulas/users-formula/pull/100#issuecomment-156350893) but it's better than nothing.