### PR TITLE
Resolve `git.config` error where minion does not have Git installed #115

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -81,6 +81,9 @@ users:
         options:
           - "StrictHostKeyChecking yes"
 
+    # Using gitconfig without Git installed will result in an error
+    # https://docs.saltstack.com/en/latest/ref/states/all/salt.states.git.html:
+    # This state module now requires git 1.6.5 (released 10 October 2009) or newer.
     gitconfig:
       user.name: B User
       user.email: buser@example.com

--- a/users/init.sls
+++ b/users/init.sls
@@ -416,6 +416,11 @@ users_googleauth-{{ svc }}-{{ name }}:
 {%- endif %}
 
 {% if 'gitconfig' in user %}
+{% if not salt['cmd.has_exec']('git') %}
+skip_{{ name }}_gitconfig_since_git_not_installed:
+  test.fail_without_changes:
+    - name: "Git configuration for user {{ name }} has been skipped because Git is not installed."
+{% else %}
 {% for key, value in user['gitconfig'].items() %}
 users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
   {% if grains['saltversioninfo'] >= (2015, 8, 0, 0) %}
@@ -432,6 +437,7 @@ users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
     - is_global: True
     {% endif %}
 {% endfor %}
+{% endif %}
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
Resolution for #115.

Credit given where credit due (IRC #salt): @babilen @Sylvain31 @RealMurphy @iggy (shame if that doesn't link correctly).

This was the answer suggested when I asked how to use Salt to simply check if Git is installed on a minion.  All I had to do was put it together.  I've tested with another git-less minion and AOK.