### PR TITLE
Create a system usergroup if user is a system user

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -73,6 +73,9 @@ users_{{ name }}_user:
     {%- elif 'uid' in user %}
     - gid: {{ user['uid'] }}
     {%- endif %}
+    {% if 'system' in user and user['system'] %}
+    - system: True
+    {% endif %}
   user.present:
     - name: {{ name }}
     - home: {{ home }}


### PR DESCRIPTION
If the user to be created is a system user, it makes no sense to create
him a primary group which is not a system group too.