### PR TITLE
Keep existing user's home and shell unless explicitly defined

### DIFF
--- a/users/bashrc.sls
+++ b/users/bashrc.sls
@@ -3,10 +3,11 @@ include:
   - users
 
 {% for name, user in pillar.get('users', {}).items() if user.absent is not defined or not user.absent %}
+{%- set current = salt.user.info(name) -%}
 {%- if user == None -%}
 {%- set user = {} -%}
 {%- endif -%}
-{%- set home = user.get('home', "/home/%s" % name) -%}
+{%- set home = user.get('home', current.get('home', "/home/%s" % name)) -%}
 {%- set manage = user.get('manage_bashrc', False) -%}
 {%- if 'prime_group' in user and 'name' in user['prime_group'] %}
 {%- set user_group = user.prime_group.name -%}

--- a/users/profile.sls
+++ b/users/profile.sls
@@ -3,10 +3,11 @@ include:
   - users
 
 {% for name, user in pillar.get('users', {}).items() if user.absent is not defined or not user.absent %}
+{%- set current = salt.user.info(name) -%}
 {%- if user == None -%}
 {%- set user = {} -%}
 {%- endif -%}
-{%- set home = user.get('home', "/home/%s" % name) -%}
+{%- set home = user.get('home', current.get('home', "/home/%s" % name)) -%}
 {%- set manage = user.get('manage_profile', False) -%}
 {%- if 'prime_group' in user and 'name' in user['prime_group'] %}
 {%- set user_group = user.prime_group.name -%}

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -5,9 +5,10 @@ include:
 
 {% set userfile_dirs = salt['cp.list_master_dirs'](prefix='users/files/user/') -%}
 {%- for username, user in salt['pillar.get']('users', {}).items() if (user.absent is not defined or not user.absent) -%}
+{%- set current = salt.user.info(username) -%}
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
-{%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), '/home/' ~ username ) -%}
+{%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}

--- a/users/vimrc.sls
+++ b/users/vimrc.sls
@@ -4,10 +4,11 @@ include:
   - vim
 
 {% for name, user in pillar.get('users', {}).items() if user.absent is not defined or not user.absent %}
+{%- set current = salt.user.info(name) -%}
 {%- if user == None -%}
 {%- set user = {} -%}
 {%- endif -%}
-{%- set home = user.get('home', "/home/%s" % name) -%}
+{%- set home = user.get('home', current.get('home', "/home/%s" % name)) -%}
 {%- set manage = user.get('manage_vimrc', False) -%}
 {%- if 'prime_group' in user and 'name' in user['prime_group'] %}
 {%- set user_group = user.prime_group.name -%}


### PR DESCRIPTION
Hi there,

This PR adds the following feature.

If a user account already exists, and home or shell are not explicitly defined in pillar configuration, current values are retained instead of being forced to /home/<user> and /bin/bash.

Use case:
I only wanted to use this formula for the sudoers and user_files function. (system)User is added as part of a package, so it already exists. Homedir and shell may vary depending on the OS/dist, so I'd like to retain it if possible.

Furthermore i noticed that all homedir references in SSH key management states could be made shorter as the choice for {{ home }} is already made