### PR TITLE
Properly handle dependencies on ssh_auth when home is not create with…

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -221,7 +221,7 @@ users_ssh_auth_{{ name }}_{{ loop.index0 }}:
     - user: {{ name }}
     - name: {{ auth }}
     - require:
-        - file: users_{{ name }}_user
+        - file: user_keydir_{{ name }}
         - user: users_{{ name }}_user
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
When CreateHome was set to false, it was impossible to use ssh_auth as the dependency was on the creation of the user directory and not on the fact that the ~/.ssh was present.