### PR TITLE
Use `contents_pillar` to work with multi-line authorized_keys file

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -11,7 +11,9 @@ users:
     # WARNING: If 'empty_password' is set to True, the 'password' statement
     # will be ignored by enabling password-less login for the user.
     empty_password: False
+    system: False
     home: /custom/buser
+    user_dir_mode: 750
     createhome: True
     roomnumber: "A-1"
     workphone: "(555) 555-5555"
@@ -34,6 +36,7 @@ users:
     sudo_defaults:
       - '!requiretty'
     shell: /bin/bash
+    remove_groups: False
     prime_group:
       name: primarygroup
       gid: 500

--- a/users/init.sls
+++ b/users/init.sls
@@ -207,9 +207,8 @@ users_authorized_keys_{{ name }}:
         {{ auth }}
         {% endfor -%}
 {% else %}
-    - contents: |
-        {%- for key_name, pillar_name in user['ssh_auth_pillar'].iteritems() %}
-        {{ salt['pillar.get'](pillar_name + ':' + key_name + ':pubkey', '') }}
+        {%- for key_name, pillar_name in user['ssh_auth_pillar'].items() %}
+    - contents_pillar: {{ pillar_name }}:{{ key_name }}:pubkey
         {%- endfor %}
 {% endif %}
 {% endif %}

--- a/users/init.sls
+++ b/users/init.sls
@@ -384,6 +384,11 @@ users_{{ users.sudoers_dir }}/{{ name }}:
       {%- endfor %}
       {%- endif %}
       {%- if 'sudo_rules' in user %}
+        ########################################################################
+        # File managed by Salt (users-formula).
+        # Your changes will be overwritten.
+        ########################################################################
+        #
       {%- for rule in user['sudo_rules'] %}
         {{ name }} {{ rule }}
       {%- endfor %}
@@ -391,10 +396,10 @@ users_{{ users.sudoers_dir }}/{{ name }}:
     - require:
       - file: users_sudoer-defaults
       - file: users_sudoer-{{ name }}
-  cmd.wait:                                                                           
+  cmd.wait:
     - name: visudo -cf {{ users.sudoers_dir }}/{{ name }} || ( rm -rvf {{ users.sudoers_dir }}/{{ name }}; exit 1 )
-    - watch:                                                                         
-      - file: {{ users.sudoers_dir }}/{{ name }}   
+    - watch:
+      - file: {{ users.sudoers_dir }}/{{ name }}
 {% endif %}
 {% else %}
 users_{{ users.sudoers_dir }}/{{ name }}:


### PR DESCRIPTION
Found some commits that I had intended to include in a PR from the end of last year!  They still apply cleanly and are probably useful.

Additional reasoning for the `Use contents_pillar to work with multiple-line authorized_keys file` commit:

1. Also consistent use of `contents_pillar` with earlier in the file
1. Replaces deprecated `iteritems`