### PR TITLE
Support for optional_groups

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -42,6 +42,9 @@ users:
       gid: 500
     groups:
       - users
+    optional_groups:
+      - some_groups_that_might
+      - not_exist_on_all_minions
     ssh_key_type: rsa
     # You can inline the private keys ...
     ssh_keys:

--- a/users/init.sls
+++ b/users/init.sls
@@ -135,6 +135,12 @@ users_{{ name }}_user:
       {% for group in user.get('groups', []) -%}
       - {{ group }}
       {% endfor %}
+    {% if 'optional_groups' in user %}
+    - optional_groups:
+      {% for optional_group in user['optional_groups'] -%}
+      - {{optional_group}}
+      {% endfor %}
+    {% endif %}
     - require:
       - group: {{ user_group }}
       {% for group in user.get('groups', []) -%}


### PR DESCRIPTION
Simple change to pass `optional_groups` from the pillar to `user.present`.
