### PR TITLE
fix warning on managed file state for /etc/sudoers.d/username

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -341,6 +341,7 @@ users_ssh_known_hosts_delete_{{ name }}_{{ loop.index0 }}:
 
 users_sudoer-{{ name }}:
   file.managed:
+    - replace: False
     - name: {{ users.sudoers_dir }}/{{ name }}
     - user: root
     - group: {{ users.root_group }}
@@ -379,6 +380,7 @@ users_sudoer-{{ name }}:
 
 users_{{ users.sudoers_dir }}/{{ name }}:
   file.managed:
+    - replace: True
     - name: {{ users.sudoers_dir }}/{{ name }}
     - contents: |
       {%- if 'sudo_defaults' in user %}


### PR DESCRIPTION
Added replace:False to file.managed sudoers.d/file

This will fix the warning:
```
[WARNING ] State for file: /etc/sudoers.d/<username> - Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
```