### PR TITLE
removed old users and group before creating new ones

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -47,6 +47,42 @@ include:
 {%- set user_group = name -%}
 {%- endif %}
 
+{% for name, user in pillar.get('users', {}).items()
+        if user.absent is defined and user.absent %}
+users_absent_user_{{ name }}:
+{% if 'purge' in user or 'force' in user %}
+  user.absent:
+    - name: {{ name }}
+    {% if 'purge' in user %}
+    - purge: {{ user['purge'] }}
+    {% endif %}
+    {% if 'force' in user %}
+    - force: {{ user['force'] }}
+    {% endif %}
+{% else %}
+  user.absent:
+    - name: {{ name }}
+{% endif -%}
+users_{{ users.sudoers_dir }}/{{ name }}:
+  file.absent:
+    - name: {{ users.sudoers_dir }}/{{ name }}
+{% endfor %}
+
+{% for user in pillar.get('absent_users', []) %}
+users_absent_user_2_{{ user }}:
+  user.absent:
+    - name: {{ name }}
+users_2_{{ users.sudoers_dir }}/{{ user }}:
+  file.absent:
+    - name: {{ users.sudoers_dir }}/{{ user }}
+{% endfor %}
+
+{% for group in pillar.get('absent_groups', []) %}
+users_absent_group_{{ group }}:
+  group.absent:
+    - name: {{ group }}
+{% endfor %}
+
 {% for group in user.get('groups', []) %}
 users_{{ name }}_{{ group }}_group:
   group.present:
@@ -452,41 +488,4 @@ users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
 {% endif %}
 {% endif %}
 
-{% endfor %}
-
-
-{% for name, user in pillar.get('users', {}).items()
-        if user.absent is defined and user.absent %}
-users_absent_user_{{ name }}:
-{% if 'purge' in user or 'force' in user %}
-  user.absent:
-    - name: {{ name }}
-    {% if 'purge' in user %}
-    - purge: {{ user['purge'] }}
-    {% endif %}
-    {% if 'force' in user %}
-    - force: {{ user['force'] }}
-    {% endif %}
-{% else %}
-  user.absent:
-    - name: {{ name }}
-{% endif -%}
-users_{{ users.sudoers_dir }}/{{ name }}:
-  file.absent:
-    - name: {{ users.sudoers_dir }}/{{ name }}
-{% endfor %}
-
-{% for user in pillar.get('absent_users', []) %}
-users_absent_user_2_{{ user }}:
-  user.absent:
-    - name: {{ name }}
-users_2_{{ users.sudoers_dir }}/{{ user }}:
-  file.absent:
-    - name: {{ users.sudoers_dir }}/{{ user }}
-{% endfor %}
-
-{% for group in pillar.get('absent_groups', []) %}
-users_absent_group_{{ group }}:
-  group.absent:
-    - name: {{ group }}
 {% endfor %}


### PR DESCRIPTION
We need to ensure that old users and groups are deleted first, before creating new ones. Otherwise user ids und group ids can conflict.