### PR TITLE
fix wrong variable name in absent_users

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -479,7 +479,7 @@ users_{{ users.sudoers_dir }}/{{ name }}:
 {% for user in pillar.get('absent_users', []) %}
 users_absent_user_2_{{ user }}:
   user.absent:
-    - name: {{ name }}
+    - name: {{ user }}
 users_2_{{ users.sudoers_dir }}/{{ user }}:
   file.absent:
     - name: {{ users.sudoers_dir }}/{{ user }}


### PR DESCRIPTION
Found this bug while using absent_users. It breaks state rendering. This patch fixes it.