### PR TITLE
Make policy kit AdminIdentitiy manageable

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -38,6 +38,8 @@ users:
       - ALL=(otheruser) /usr/bin/script.sh
     sudo_defaults:
       - '!requiretty'
+    # enable polkitadmin to make user an AdminIdentity for polkit
+    polkitadmin: True
     shell: /bin/bash
     remove_groups: False
     prime_group:

--- a/users/init.sls
+++ b/users/init.sls
@@ -22,7 +22,6 @@
 
 {%- if used_sudo or used_googleauth or used_user_files %}
 include:
-  - users.polkit
 {%- if used_sudo %}
   - users.sudo
 {%- endif %}
@@ -33,6 +32,7 @@ include:
   - users.user_files
 {%- endif %}
 {%- endif %}
+  - users.polkit
 
 {% for name, user in pillar.get('users', {}).items()
         if user.absent is not defined or not user.absent %}

--- a/users/init.sls
+++ b/users/init.sls
@@ -417,6 +417,27 @@ users_{{ users.sudoers_dir }}/{{ name }}:
     - name: {{ users.sudoers_dir }}/{{ name }}
 {% endif %}
 
+# Policykit AdminIdentities Logik
+{%- if 'polkitadmin' in user and user['polkitadmin'] %}
+users_{{ users.polkit_dir }}/{{ name }}:
+  file.managed:
+    - replace: True
+    - onlyif: 'test -d {{ users.polkit_dir }}'
+    - name: {{ users.polkit_dir }}/{{ name }}.conf
+    - contents: |
+        ########################################################################
+        # File managed by Salt (users-formula).
+        # Your changes will be overwritten.
+        ########################################################################
+        #
+        [Configuration]
+        AdminIdentities=unix-user:{{ name }}
+{%- else %}
+users_{{ users.polkit_dir }}/{{ name }}:
+  file.absent:
+    - name: {{ users.polkit_dir }}/{{ name }}.conf
+{%- endif %}
+
 {%- if 'google_auth' in user %}
 {%- for svc in user['google_auth'] %}
 users_googleauth-{{ svc }}-{{ name }}:
@@ -486,6 +507,9 @@ users_absent_user_{{ name }}:
 users_{{ users.sudoers_dir }}/{{ name }}:
   file.absent:
     - name: {{ users.sudoers_dir }}/{{ name }}
+users_{{ users.polkit_dir }}/{{ name }}:
+  file.absent:
+    - name: {{ users.polkit_dir }}/{{ name }}.conf
 {% endfor %}
 
 {% for user in pillar.get('absent_users', []) %}
@@ -495,6 +519,9 @@ users_absent_user_2_{{ user }}:
 users_2_{{ users.sudoers_dir }}/{{ user }}:
   file.absent:
     - name: {{ users.sudoers_dir }}/{{ user }}
+users_2_{{ users.polkit_dir }}/{{ name }}:
+  file.absent:
+    - name: {{ users.polkit_dir }}/{{ name }}.conf
 {% endfor %}
 
 {% for group in pillar.get('absent_groups', []) %}

--- a/users/init.sls
+++ b/users/init.sls
@@ -101,6 +101,8 @@ users_{{ name }}_user:
     {% endif -%}
     {% if 'prime_group' in user and 'gid' in user['prime_group'] -%}
     - gid: {{ user['prime_group']['gid'] }}
+    {% elif 'prime_group' in user and 'name' in user['prime_group']%}
+    - gid: {{ user['prime_group']['name'] }}
     {% else -%}
     - gid_from_name: True
     {% endif -%}

--- a/users/init.sls
+++ b/users/init.sls
@@ -101,7 +101,7 @@ users_{{ name }}_user:
     {% endif -%}
     {% if 'prime_group' in user and 'gid' in user['prime_group'] -%}
     - gid: {{ user['prime_group']['gid'] }}
-    {% elif 'prime_group' in user and 'name' in user['prime_group']%}
+    {% elif 'prime_group' in user and 'name' in user['prime_group'] %}
     - gid: {{ user['prime_group']['name'] }}
     {% else -%}
     - gid_from_name: True

--- a/users/init.sls
+++ b/users/init.sls
@@ -22,6 +22,7 @@
 
 {%- if used_sudo or used_googleauth or used_user_files %}
 include:
+  - users.polkit
 {%- if used_sudo %}
   - users.sudo
 {%- endif %}
@@ -417,27 +418,6 @@ users_{{ users.sudoers_dir }}/{{ name }}:
     - name: {{ users.sudoers_dir }}/{{ name }}
 {% endif %}
 
-# Policykit AdminIdentities Logik
-{%- if 'polkitadmin' in user and user['polkitadmin'] %}
-users_{{ users.polkit_dir }}/{{ name }}:
-  file.managed:
-    - replace: True
-    - onlyif: 'test -d {{ users.polkit_dir }}'
-    - name: {{ users.polkit_dir }}/{{ name }}.conf
-    - contents: |
-        ########################################################################
-        # File managed by Salt (users-formula).
-        # Your changes will be overwritten.
-        ########################################################################
-        #
-        [Configuration]
-        AdminIdentities=unix-user:{{ name }}
-{%- else %}
-users_{{ users.polkit_dir }}/{{ name }}:
-  file.absent:
-    - name: {{ users.polkit_dir }}/{{ name }}.conf
-{%- endif %}
-
 {%- if 'google_auth' in user %}
 {%- for svc in user['google_auth'] %}
 users_googleauth-{{ svc }}-{{ name }}:
@@ -507,9 +487,6 @@ users_absent_user_{{ name }}:
 users_{{ users.sudoers_dir }}/{{ name }}:
   file.absent:
     - name: {{ users.sudoers_dir }}/{{ name }}
-users_{{ users.polkit_dir }}/{{ name }}:
-  file.absent:
-    - name: {{ users.polkit_dir }}/{{ name }}.conf
 {% endfor %}
 
 {% for user in pillar.get('absent_users', []) %}
@@ -519,9 +496,6 @@ users_absent_user_2_{{ user }}:
 users_2_{{ users.sudoers_dir }}/{{ user }}:
   file.absent:
     - name: {{ users.sudoers_dir }}/{{ user }}
-users_2_{{ users.polkit_dir }}/{{ name }}:
-  file.absent:
-    - name: {{ users.polkit_dir }}/{{ name }}.conf
 {% endfor %}
 
 {% for group in pillar.get('absent_groups', []) %}

--- a/users/map.jinja
+++ b/users/map.jinja
@@ -10,6 +10,7 @@
     'bash_package': 'bash',
     'sudo_package': 'sudo',
     'googleauth_package': 'libpam-google-authenticator',
+    'polkit_dir': '/etc/polkit-1/localauthority.conf.d',
   },
   'Gentoo': {
     'sudoers_dir': '/etc/sudoers.d',
@@ -43,5 +44,6 @@
     'bash_package': 'bash',
     'sudo_package': 'sudo',
     'googleauth_package': 'libpam-google-authenticator',
+    'polkit_dir': '/etc/polkit-1/localauthority.conf.d',
   },
 }, merge=salt['pillar.get']('users:lookup')) %}

--- a/users/map.jinja
+++ b/users/map.jinja
@@ -11,6 +11,7 @@
     'sudo_package': 'sudo',
     'googleauth_package': 'libpam-google-authenticator',
     'polkit_dir': '/etc/polkit-1/localauthority.conf.d',
+    'polkit_defaults': 'unix-group:sudo;'
   },
   'Gentoo': {
     'sudoers_dir': '/etc/sudoers.d',
@@ -45,5 +46,6 @@
     'sudo_package': 'sudo',
     'googleauth_package': 'libpam-google-authenticator',
     'polkit_dir': '/etc/polkit-1/localauthority.conf.d',
+    'polkit_defaults': 'unix-group:sudo;'
   },
 }, merge=salt['pillar.get']('users:lookup')) %}

--- a/users/polkit.sls
+++ b/users/polkit.sls
@@ -24,7 +24,7 @@ users_{{ users.polkit_dir }}/99salt-users-formula.conf:
         ########################################################################
         #
         [Configuration]
-        AdminIdentities={{ polkitusers.value }}
+        AdminIdentities={{ users.polkit_defaults }}{{ polkitusers.value }}
 {% else %}
 users_{{ users.polkit_dir }}/99salt-users-formula.conf_delete:
   file.absent:

--- a/users/polkit.sls
+++ b/users/polkit.sls
@@ -1,0 +1,32 @@
+{% from "users/map.jinja" import users with context %}
+{% set polkitusers = {} %}
+{% set polkitusers = {'value': ''} %}
+
+{% for name, user in pillar.get('users', {}).items() %}
+  {% if user.absent is not defined or not user.absent %}
+    {% if 'polkitadmin' in user and user['polkitadmin'] %}
+      {% if polkitusers.update({'value': polkitusers.value + 'unix-user:' + name + ';'}) %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{% if polkitusers.value != '' %}
+users_{{ users.polkit_dir }}/99salt-users-formula.conf:
+  file.managed:
+    - replace: True
+    - onlyif: 'test -d {{ users.polkit_dir }}'
+    - name: {{ users.polkit_dir }}/99salt-users-formula.conf
+    - contents: |
+        ########################################################################
+        # File managed by Salt (users-formula).
+        # Your changes will be overwritten.
+        ########################################################################
+        #
+        [Configuration]
+        AdminIdentities={{ polkitusers.value }}
+{% else %}
+users_{{ users.polkit_dir }}/99salt-users-formula.conf_delete:
+  file.absent:
+    - name: {{ users.polkit_dir }}/99salt-users-formula.conf
+{% endif %}


### PR DESCRIPTION
Hey there, this states can be used to configure AdminIdentity for polkit.
This can be usefull if you don't want to add a user to group sudo but allow to install updates for example on a Desktop System.