### PR TITLE
Add ability to specify mode for files and symlinks in user_files

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -119,6 +119,11 @@ users:
       # should be a salt fileserver path either with or without 'salt://'
       # if not present, it defaults to 'salt://users/files/user/<username>
       source: users/files/default
+      # You can specify octal mode for files and symlinks that will be copied. Since version 2016.11.0
+      # it's possible to use 'keep' for file_mode, to preserve file original mode, thus you can save
+      # execution bit for example.
+      file_mode: keep
+      sym_mode: 640
 
   ## Absent user
   cuser:

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,6 +9,8 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
+{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), False) -%}
+{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), False) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -35,6 +37,12 @@ users_userfiles_{{ username }}_recursive:
     - user: {{ username }}
     - group: {{ user_group }}
     - clean: False
+    {% if user_files_file_mode -%}
+    - file_mode: {{ user_files_file_mode }}
+    {% endif -%}
+    {% if user_files_sym_mode -%}
+    - sym_mode: {{ user_files_sym_mode }}
+    {% endif -%}
     - include_empty: True
     - keep_symlinks: True
     - require:

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,8 +9,8 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
-{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), False) -%}
-{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), False) -%}
+{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), None) -%}
+{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), None) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -37,10 +37,10 @@ users_userfiles_{{ username }}_recursive:
     - user: {{ username }}
     - group: {{ user_group }}
     - clean: False
-    {% if user_files_file_mode -%}
+    {% if user_files_file_mode is not None -%}
     - file_mode: {{ user_files_file_mode }}
     {% endif -%}
-    {% if user_files_sym_mode -%}
+    {% if user_files_sym_mode is not None -%}
     - sym_mode: {{ user_files_sym_mode }}
     {% endif -%}
     - include_empty: True

--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -9,8 +9,8 @@ include:
 {%- set user_files = salt['pillar.get'](('users:' ~ username ~ ':user_files'), {'enabled': False}) -%}
 {%- set user_group = salt['pillar.get'](('users:' ~ username ~ ':prime_group:name'), username) -%}
 {%- set user_home = salt['pillar.get'](('users:' ~ username ~ ':home'), current.get('home', '/home/' ~ username )) -%}
-{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), None) -%}
-{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), None) -%}
+{%- set user_files_file_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:file_mode'), False) -%}
+{%- set user_files_sym_mode = salt['pillar.get'](('users:' ~ username ~ ':user_files:sym_mode'), False) -%}
 {%- if user_files.enabled -%}
 
 {%- if user_files.source is defined -%}
@@ -37,10 +37,10 @@ users_userfiles_{{ username }}_recursive:
     - user: {{ username }}
     - group: {{ user_group }}
     - clean: False
-    {% if user_files_file_mode is not None -%}
+    {% if user_files_file_mode -%}
     - file_mode: {{ user_files_file_mode }}
     {% endif -%}
-    {% if user_files_sym_mode is not None -%}
+    {% if user_files_sym_mode -%}
     - sym_mode: {{ user_files_sym_mode }}
     {% endif -%}
     - include_empty: True


### PR DESCRIPTION
This PR add minor improvement by adding ability to specify mode for files and symlinks in user_files.
Unfortunately dir_mode interfere with user_dir_mode therefore I didn't add it.
For me key value is new (since 2016.11.0) 'keep' option for file_mode, now files in $HOME/bin can save their execution bit.