### PR TITLE
fixed insertion of multiple authorized keys via ssh_auth_pillar

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -217,8 +217,9 @@ users_authorized_keys_{{ name }}:
         {{ auth }}
         {% endfor -%}
 {% else %}
+    - contents: |
         {%- for key_name, pillar_name in user['ssh_auth_pillar'].items() %}
-    - contents_pillar: {{ pillar_name }}:{{ key_name }}:pubkey
+        {{ salt['pillar.get'](pillar_name + ':' + key_name + ':pubkey', '') }}
         {%- endfor %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
The creation of ssh authorized_keys containing multiple keys is broken if contents_pillar option is used. It only used the first item in list. I "reverted" it to use the content option, which works now.