### PR TITLE
(Re-)enable pillar users-formula:lookup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,3 +51,19 @@ This depends on the vim-formula to be installed.
 ---------------
 
 Permits the abitrary management of files. See pillar.example for configuration details.
+
+Overriding default values
+=========================
+
+In order to separate actual user account definitions from configuration the pillar `users-formula` was introduced:
+
+```yaml
+users:
+  myuser:
+    # stuff
+
+users-formula:
+  lookup:
+    root_group: toor
+    shell: '/bin/zsh'
+```

--- a/README.rst
+++ b/README.rst
@@ -55,9 +55,9 @@ Permits the abitrary management of files. See pillar.example for configuration d
 Overriding default values
 =========================
 
-In order to separate actual user account definitions from configuration the pillar `users-formula` was introduced:
+In order to separate actual user account definitions from configuration the pillar ``users-formula`` was introduced:
 
-.. code-bock:: yaml
+.. code-block:: yaml
 
     users:
       myuser:

--- a/README.rst
+++ b/README.rst
@@ -57,13 +57,12 @@ Overriding default values
 
 In order to separate actual user account definitions from configuration the pillar `users-formula` was introduced:
 
-```yaml
-users:
-  myuser:
-    # stuff
+.. code-bock:: yaml
+    users:
+      myuser:
+        # stuff
 
-users-formula:
-  lookup:
-    root_group: toor
-    shell: '/bin/zsh'
-```
+    users-formula:
+      lookup:
+        root_group: toor
+        shell: '/bin/zsh'

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ Overriding default values
 In order to separate actual user account definitions from configuration the pillar `users-formula` was introduced:
 
 .. code-bock:: yaml
+
     users:
       myuser:
         # stuff

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,7 @@
+users-formula:
+  lookup:  # override the defauls in map.jinja
+    root_group: root
+
 users:
   ## Minimal required pillar values
   auser:

--- a/users/map.jinja
+++ b/users/map.jinja
@@ -44,4 +44,4 @@
     'sudo_package': 'sudo',
     'googleauth_package': 'libpam-google-authenticator',
   },
-}, merge=salt['pillar.get']('users:lookup')) %}
+}, merge=salt['pillar.get']('users-formula:lookup')) %}


### PR DESCRIPTION
Successor of #154 

```yaml
users:
  lookup:
    # stuff
```
Actually defined another user. This PR introduces `users-formula` to solve this issue.