### PR TITLE
Broken conditional and lack of line spacing

### DIFF
--- a/users/user_files.sls
+++ b/users/user_files.sls
@@ -37,9 +37,9 @@ users_userfiles_{{ username }}_recursive:
     - source: {{ file_source }}
     - user: {{ username }}
     - group: {{ user_group }}
-    {%- if user_files_template is not None -%}
+    {% if user_files_template -%}
     - template: {{ user_files_template }}
-    {%- endif -%}
+    {% endif -%}
     - clean: False
     {% if user_files_file_mode -%}
     - file_mode: {{ user_files_file_mode }}


### PR DESCRIPTION
Change to include `template` caused compile issue due to the wrong format for the conditional.
Additionally, results produced from the template would not have had proper line-spacing on the new entry.