### PR TITLE
corrected saltversioninfo check expression

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -462,7 +462,7 @@ users_googleauth-{{ svc }}-{{ name }}:
 {% if 'gitconfig' in user %}
 {% for key, value in user['gitconfig'].items() %}
 users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
-  {% if grains['saltversioninfo'] >= (2015, 8, 0, 0) %}
+  {% if grains['saltversioninfo'] >= [2015, 8, 0, 0] %}
   git.config_set:
   {% else %}
   git.config:
@@ -470,7 +470,7 @@ users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
     - name: {{ key }}
     - value: "{{ value }}"
     - user: {{ name }}
-    {% if grains['saltversioninfo'] >= (2015, 8, 0, 0) %}
+    {% if grains['saltversioninfo'] >= [2015, 8, 0, 0] %}
     - global: True
     {% else %}
     - is_global: True


### PR DESCRIPTION
The [check of the saltversioninfo](https://github.com/saltstack-formulas/users-formula/blob/e5e9cd8fcfaaa8fe76aa3ce1d98436b156fb9171/users/init.sls#L465) doesn't work for the git config setup. This change fixes the problem. I looked for saltversioninfo checks in [other formulas](https://github.com/saltstack-formulas/maven-formula/blob/77db29e532e032b724bca376860af6d9203edad2/maven/init.sls#L35), to find out how it is done.  


The error  for me was always:
```
----------
          ID: users_root_user_gitconfig_0
    Function: git.config
        Name: push.default
      Result: False
     Comment: State 'git.config' was not found in SLS 'users'
              Reason: 'git.config' is not available.
     Changes:
----------
          ID: users_root_user_gitconfig_1
    Function: git.config
        Name: url."https://".insteadOf
      Result: False
     Comment: State 'git.config' was not found in SLS 'users'
              Reason: 'git.config' is not available.
     Changes:
----------
          ID: users_root_user_gitconfig_2
    Function: git.config
        Name: user.name
      Result: False
     Comment: State 'git.config' was not found in SLS 'users'
              Reason: 'git.config' is not available.
     Changes:
----------
          ID: users_root_user_gitconfig_3
    Function: git.config
        Name: user.email
      Result: False
     Comment: State 'git.config' was not found in SLS 'users'
              Reason: 'git.config' is not available.
     ...
```