### PR TITLE
Support "salt://path_to_keyname" ssh_key definition in users:"user name":ssh_keys:"privkey|pubkey" pillar data

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -57,6 +57,9 @@ users:
     ssh_keys:
       privkey: PRIVATEKEY
       pubkey: PUBLICKEY
+      # or you can provide path to key on Salt fileserver
+      privkey: salt://path_to_PRIVATEKEY
+      pubkey: salt://path_to_PUBLICKEY
       # you can provide multiple keys, the keyname is taken as filename
       # make sure your public keys suffix is .pub
       foobar: PRIVATEKEY

--- a/users/init.sls
+++ b/users/init.sls
@@ -194,7 +194,12 @@ users_{{ name }}_{{ key_name }}_key:
     - mode: 600
       {% endif %}
     - show_diff: False
+    {%- set key_value = salt['pillar.get']('users:'+name+':ssh_keys:'+_key) %}
+    {%- if 'salt://' in key_value[:7] %}
+    - source: {{ key_value }}
+    {%- else %}
     - contents_pillar: users:{{ name }}:ssh_keys:{{ _key }}
+    {%- endif %}
     - require:
       - user: users_{{ name }}_user
       {% for group in user.get('groups', []) %}


### PR DESCRIPTION
Hi 
I don't want to show private part ssh key into pillar data. I offer this feature.

Pillar example:
```YAML
users:
  user_name:
    ssh_keys:
      privkey: salt://path_to_PRIVATEKEY
      pubkey: salt://path_to_PUBLICKEY
```