### PR TITLE
Do not try to run git config when git is not available

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -446,10 +446,6 @@ users_googleauth-{{ svc }}-{{ name }}:
 {%- endfor %}
 {%- endif %}
 
-#
-# if not salt['cmd.has_exec']('git')
-# fails even if git is installed
-#
 # this doesn't work (Salt bug), therefore need to run state.apply twice
 #include:
 #  - users
@@ -460,6 +456,7 @@ users_googleauth-{{ svc }}-{{ name }}:
 #      - sls: users
 #
 {% if 'gitconfig' in user %}
+{% if salt['cmd.has_exec']('git') %}
 {% for key, value in user['gitconfig'].items() %}
 users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
   {% if grains['saltversioninfo'] >= [2015, 8, 0, 0] %}
@@ -476,6 +473,7 @@ users_{{ name }}_user_gitconfig_{{ loop.index0 }}:
     - is_global: True
     {% endif %}
 {% endfor %}
+{% endif %}
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
The state will not fail gracefully, instead you will get
an error like this one:

          ID: users_rhertzog_user_gitconfig_0
    Function: git.config_set
        Name: alias.br
      Result: False
     Comment: State 'git.config_set' was not found in SLS 'users'
              Reason: 'git' __virtual__ returned False
     Changes:

And since pillar data can't be (easily) tuned according to minion's
status, we really need this check here.

My tests with Salt 2017.7.3 have shown that cmd.has_exec() is reliable
for this, contrary the what the comment was implying.