### PR TITLE
sudo already installed on Darwin

### DIFF
--- a/users/map.jinja
+++ b/users/map.jinja
@@ -1,5 +1,16 @@
 # vim: sts=2 ts=2 sw=2 et ai
+
 {% set users = salt['grains.filter_by']({
+  'MacOS': {
+    'sudoers_dir': '/etc/sudoers.d',
+    'sudoers_file': '/etc/sudoers',
+    'googleauth_dir': '/etc/google_authenticator.d',
+    'shell': '/bin/bash',
+    'visudo_shell': '/bin/bash',
+    'bash_package': 'bash',
+    'sudo_package': 'sudo',
+    'googleauth_package': 'google-authenticator-libpam',
+  },
   'Debian': {
     'sudoers_dir': '/etc/sudoers.d',
     'sudoers_file': '/etc/sudoers',
@@ -56,3 +67,8 @@
     'googleauth_package': 'libpam-google-authenticator',
   },
 }, merge=salt['pillar.get']('users-formula:lookup')) %}
+
+{% if grains.os == 'MacOS' %}
+  {% set group = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
+  {% do users.update({'root_group': group,}) %}
+{% endif %}

--- a/users/sudo.sls
+++ b/users/sudo.sls
@@ -11,6 +11,7 @@ users_sudo-package:
     - name: {{ users.sudo_package }}
     - require:
       - file: {{ users.sudoers_dir }} 
+    - unless: test "`uname`" = "Darwin"
 
 users_{{ users.sudoers_dir }}:
   file.directory:


### PR DESCRIPTION
PR fixes these issues.
```
      ID: users_sudo-package
    Function: pkg.installed
        Name: sudo
      Result: False
     Comment: Brew command failed. Additional info follows:

              result:
                  ----------
                  pid:
                      15807
                  retcode:
                      1
                  stderr:
                      Error: No available formula with the name "sudo"
                      Warning: homebrew/core is shallow clone. To get complete history run:
                        git -C "$(brew --repo homebrew/core)" fetch --unshallow

                      Error: No previously deleted formula found.
                      ==> Searching local taps...
                      Error: No similarly named formulae found.
                      ==> Searching taps on GitHub...
                      Error: No formulae found in taps.
                  stdout:
                      ==> Searching for a previously deleted formula (in the last month)...
                      ==> Searching for similarly named formulae...
                      ==> Searching taps...


          ID: users_sudoer-messi
    Function: file.managed
        Name: /etc/sudoers.d/messi
      Result: False
     Comment: Group root is not available
     Started: 20:29:26.122359
    Duration: 2.55 ms
     Changes:
----------
          ID: users_/etc/sudoers.d/messi
    Function: file.managed
        Name: /etc/sudoers.d/messi
      Result: False
     Comment: One or more requisite failed: users.users_sudoer-messi, users.sudo.users_sudoer-defaults
     Changes:
----------
          ID: users_/etc/sudoers.d/messi
    Function: cmd.wait
        Name: visudo -cf /etc/sudoers.d/messi || ( rm -rvf /etc/sudoers.d/messi; exit 1 )
      Result: False
     Comment: One or more requisite failed: users.users_/etc/sudoers.d/messi, users.users_sudoer-messi
     Changes:
```