### PR TITLE
Fix default behavior of copying /etc/skel when creating home directory

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -64,7 +64,7 @@ users_{{ name }}_{{ group }}_group:
 {% if user.get('createhome', True) %}
 users_{{ name }}_user_prereq:
   file.directory:
-    - name: {{ home }}
+    - name: {{ salt['file.dirname'](home) }}
     - makedirs: True
     - prereq:
       - user: users_{{ name }}_user


### PR DESCRIPTION
Since https://github.com/saltstack-formulas/users-formula/pull/182 the
home directory was created by salt which prevent "adduser" behavior to
copy /etc/skel in newly created directory.

Ensure the parent directory of the home dir is existing instead.