### PR TITLE
Allow state to update the gid

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -9,6 +9,7 @@ users:
     fullname: A User
 
   ## Full list of pillar values
+  allow_gid_change: False
   buser:
     fullname: B User
     password: $6$w.............
@@ -27,6 +28,7 @@ users:
     workphone: "(555) 555-5555"
     homephone: "(555) 555-5551"
     manage_vimrc: False
+    allow_gid_change: True
     manage_bashrc: False
     manage_profile: False
     expire: 16426

--- a/users/defaults.yaml
+++ b/users/defaults.yaml
@@ -4,3 +4,6 @@
 users-formula:
   use_vim_formula: False
 
+users:
+  allow_gid_change: True
+

--- a/users/init.sls
+++ b/users/init.sls
@@ -151,6 +151,9 @@ users_{{ name }}_user:
     {% if not user.get('unique', True) %}
     - unique: False
     {% endif %}
+    {%- if grains['saltversioninfo'] >= [2018, 3, 1] %}
+    - allow_gid_change: {{ users.allow_gid_change if 'allow_gid_change' not in user else user['allow_gid_change'] }}
+    {%- endif %}
     {% if 'expire' in user -%}
         {% if grains['kernel'].endswith('BSD') and
             user['expire'] < 157766400 %}


### PR DESCRIPTION
This PR allows `user.present` state to change the `gid` auto-generated by `gid_from_name` parameter when the pillar data needs this. 

The state fails when `gid_from_name` clashes with `optional_groups` pillar data for example.
```
Encountered error checking for needed changes. Additional info follows
Changing gid (20 -> 507) not permitted
```

For implementation, `users.allow_gid_change: True` is global default so Salt can fix this situation.  To address cavet that this parameter _will not change file ownership_, .. formula users can set `users.allow_gid_change: False` override per-user affected.

