### PR TITLE
[users/init] use dir_mode in addition to mode

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -199,6 +199,7 @@ user_keydir_{{ name }}:
     - group: {{ user_group }}
     - makedirs: True
     - mode: 700
+    - dir_mode: 700
     - require:
       - user: {{ name }}
       - group: {{ user_group }}


### PR DESCRIPTION
To get it to work with RHEL7 with salt 2018.x