### PR TITLE
add example of groups init into pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,13 @@ users-formula:
   lookup:  # override the defauls in map.jinja
     root_group: root
 
+# group initialization
+groups:
+  foo:
+    state: present
+    gid: 500
+    system: False
+
 users:
   ## Minimal required pillar values
   auser:


### PR DESCRIPTION
Add `groups` section into `pillar.example` for function below:

https://github.com/saltstack-formulas/users-formula/blob/b8c6844e1000f8977e1c3a5fcc096914950f5a5d/users/init.sls#L7-L15