### PR TITLE
fix(macos): ensure correct prime_group value

### DIFF
--- a/users/map.jinja
+++ b/users/map.jinja
@@ -89,5 +89,6 @@
 
 {% if grains.os == 'MacOS' %}
   {% set group = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
-  {% do users.update({'root_group': group,}) %}
+  {% do users.update({'root_group': group,
+                      'prime_group': group}) %}
 {% endif %}


### PR DESCRIPTION
Add `prime_group` for MacOS. 
Fixes "no group gid 1000" issue
Verified on MacOS Mojave.
```
          ID: users_bash-package
		    Function: pkg.installed
		        Name: bash
		      Result: True
		     Comment: All specified packages are already installed
		     Started: 22:51:20.985386
		    Duration: 2925.297 ms
		     Changes:   
		----------
		          ID: users_/etc/sudoers.d
		    Function: file.directory
		        Name: /etc/sudoers.d
		      Result: True
		     Comment: Directory /etc/sudoers.d updated
		     Started: 22:51:23.914410
		    Duration: 1.298 ms
		     Changes:   
		              ----------
		              /etc/sudoers.d:
		                  New Dir
		----------
		          ID: users_sudo-package
		    Function: pkg.installed
		        Name: sudo
		      Result: True
		     Comment: unless condition is true
		     Started: 22:51:23.915869
		    Duration: 1224.78 ms
		     Changes:   
		----------
		          ID: users_sudoer-defaults
		    Function: file.append
		        Name: /etc/sudoers
		      Result: True
		     Comment: Appended 2 lines
		     Started: 22:51:25.141484
		    Duration: 70.359 ms
		     Changes:   
		              ----------
		              diff:
		                  --- 
		                  
		                  +++ 
		                  
		                  @@ -45,3 +45,5 @@
		                  
		                   # %users  localhost=/sbin/shutdown -h now
		                   ALL ALL=(ALL)                   NOPASSWD:/opt/dplat/bin/Revision/CMUpdatePackage/Installer.app/Contents/MacOS/I  nstaller
		                   ALL ALL=(ALL)     NOPASSWD:/opt/dplat/bin/UpdatePackageInstaller.app/Contents/MacOS/UpdatePackage    Installer
		                  +Defaults   secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
		                  +#includedir /etc/sudoers.d
		----------
		          ID: users_bobby_user
		    Function: group.present
		        Name: bobby
		      Result: True
		     Comment: Group bobby is present and up to date
		     Started: 22:51:25.212008
		    Duration: 37.56 ms
		     Changes:   
		----------
		          ID: users_bobby_user
		    Function: user.present
		        Name: bobby
		      Result: True
		     Comment: User bobby is present and up to date
		     Started: 22:51:25.249779
		    Duration: 413.798 ms
		     Changes:   
		----------
		          ID: users_sudoer-bobby
		    Function: file.managed
		        Name: /etc/sudoers.d/bobby
		      Result: True
		     Comment: Empty file
		     Started: 22:51:25.663928
		    Duration: 3.953 ms
		     Changes:   
		              ----------
		              group:
		                  bobby
		              mode:
		                  0440
		              new:
		                  file /etc/sudoers.d/bobby created
		----------
		          ID: users_/etc/sudoers.d/bobby
		    Function: file.managed
		        Name: /etc/sudoers.d/bobby
		      Result: True
		     Comment: File /etc/sudoers.d/bobby updated
		     Started: 22:51:25.668581
		    Duration: 22.738 ms
		     Changes:   
		              ----------
		              diff:
		                  --- 
		                  +++ 
		                  @@ -0,0 +1,6 @@
		                  +########################################################################
		                  +# File managed by Salt (users-formula).
		                  +# Your changes will be overwritten.
		                  +########################################################################
		                  +#
		                  +bobby ALL=(ALL) ALL
		----------
		          ID: users_/etc/sudoers.d/bobby
		    Function: cmd.wait
		        Name: visudo -cf /etc/sudoers.d/bobby || ( rm -rvf /etc/sudoers.d/bobby; exit 1 )
		      Result: True
		     Comment: Command "visudo -cf /etc/sudoers.d/bobby || ( rm -rvf /etc/sudoers.d/bobby; exit 1 )" run
		     Started: 22:51:25.692352
		    Duration: 7.629 ms
		     Changes:   
		              ----------
		              pid:
		                  63558
		              retcode:
		                  0
		              stderr:
		              stdout:
		                  /etc/sudoers.d/bobby: parsed OK
		
		Summary for local
		------------
		Succeeded: 9 (changed=5)
```