### PR TITLE
fix(init): replace `gid_from_name` (deprecated in `develop`)

### DIFF
--- a/users/init.sls
+++ b/users/init.sls
@@ -144,7 +144,7 @@ users_{{ name }}_user:
     {% elif 'prime_group' in user and 'name' in user['prime_group'] %}
     - gid: {{ user['prime_group']['name'] }}
     {% else -%}
-    - gid_from_name: True
+    - gid: {{ name }}
     {% endif -%}
     {% if 'fullname' in user %}
     - fullname: {{ user['fullname'] }}


### PR DESCRIPTION
* Close #198
* All details in that issue
* Solution based upon:
  - https://github.com/saltstack-formulas/vault-formula/pull/35#issuecomment-509854411

---

While this repo doesn't have any testing so far, I've been working on `semantic-release`, so I've been able to test this change here: https://travis-ci.org/myii/users-formula/builds/562948812.  `opensuse` is just being a pain as usual, it's not failing with anything to do with this change.