### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -49,16 +49,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/default.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -2,7 +2,7 @@
 # vim: ft=yaml
 ---
 users-formula:
-  use_vim_formula: True
+  use_vim_formula: true
   lookup:  # override the defauls in map.jinja
     root_group: root
 
@@ -11,19 +11,19 @@ groups:
   foo:
     state: present
     gid: 1500
-    system: False
+    system: false
   badguys:
-    absent: True
+    absent: true
   niceguys:
     gid: 4242
-    system: False
+    system: false
     addusers: root
     delusers: toor
   ssl-cert:
-    system: True
+    system: true
     members:
-    - www-data
-    - openldap
+      - www-data
+      - openldap
 
 users:
   ## Minimal required pillar values
@@ -34,29 +34,29 @@ users:
   buser:
     fullname: B User
     password: $6$w.............
-    enforce_password: True
-    # WARNING: If 'empty_password' is set to True, the 'password' statement
+    enforce_password: true
+    # WARNING: If 'empty_password' is set to true, the 'password' statement
     # will be ignored by enabling password-less login for the user.
-    empty_password: False
-    hash_password: False
-    system: False
+    empty_password: false
+    hash_password: false
+    system: false
     home: /custom/buser
     homedir_owner: buser
     homedir_group: primarygroup
     user_dir_mode: 750
-    createhome: True
+    createhome: true
     roomnumber: "A-1"
     workphone: "(555) 555-5555"
     homephone: "(555) 555-5551"
-    manage_vimrc: False
-    allow_gid_change: False
-    manage_bashrc: False
-    manage_profile: False
+    manage_vimrc: false
+    allow_gid_change: false
+    manage_bashrc: false
+    manage_profile: false
     expire: 16426
     # Disables user management except sudo rules.
     # Useful for setting sudo rules for system accounts created by package instalation
-    sudoonly: False
-    sudouser: True
+    sudoonly: false
+    sudouser: true
     # sudo_rules doesn't need the username as a prefix for the rule
     # this is added automatically by the formula.
     # ----------------------------------------------------------------------
@@ -70,9 +70,9 @@ users:
     sudo_defaults:
       - '!requiretty'
     # enable polkitadmin to make user an AdminIdentity for polkit
-    polkitadmin: True
+    polkitadmin: true
     shell: /bin/bash
-    remove_groups: False
+    remove_groups: false
     prime_group:
       name: primarygroup
       gid: 1501
@@ -82,10 +82,10 @@ users:
       - some_groups_that_might
       - not_exist_on_all_minions
     ssh_key_type: rsa
-    # You can inline the private keys ...
     ssh_keys:
-      privkey: PRIVATEKEY
-      pubkey: PUBLICKEY
+      # You can inline the private keys ...
+      # privkey: PRIVATEKEY
+      # pubkey: PUBLICKEY
       # or you can provide path to key on Salt fileserver
       privkey: salt://path_to_PRIVATEKEY
       pubkey: salt://path_to_PUBLICKEY
@@ -114,7 +114,7 @@ users:
     ssh_auth_sources:
       - salt://keys/buser.id_rsa.pub
     ssh_auth_sources.absent:
-      - salt://keys/deleteduser.id_rsa.pub # PUBLICKEY_FILE_TO_BE_REMOVED
+      - salt://keys/deleteduser.id_rsa.pub  # PUBLICKEY_FILE_TO_BE_REMOVED
     # Manage the ~/.ssh/config file
     ssh_known_hosts:
       importanthost:
@@ -122,7 +122,7 @@ users:
         fingerprint: 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48
         key: PUBLICKEY
         enc: ssh-rsa
-        hash_known_hosts: True
+        hash_known_hosts: true
         timeout: 5
         fingerprint_hash_type: sha256
     ssh_known_hosts.absent:
@@ -150,7 +150,7 @@ users:
       - push.default
       - color\..+
 
-    google_2fa: True
+    google_2fa: true
     google_auth:
       sshd: |
         SOMEGAUTHHASHVAL
@@ -163,31 +163,33 @@ users:
         33333333
         44444444
         55555555
-    # unique: True allows user to have non unique uid
-    unique: False
+    # unique: true allows user to have non unique uid
+    unique: false
     uid: 1001
 
     user_files:
-      enabled: True
-      # 'source' allows you to define an arbitrary directory to sync, useful to use for default files.
+      enabled: true
+      # 'source' allows you to define an arbitrary directory to sync,
+      # useful to use for default files.
       # should be a salt fileserver path either with or without 'salt://'
       # if not present, it defaults to 'salt://users/files/user/<username>
       source: users/files
       # template: jinja
-      # You can specify octal mode for files and symlinks that will be copied. Since version 2016.11.0
-      # it's possible to use 'keep' for file_mode, to preserve file original mode, thus you can save
-      # execution bit for example.
+      # You can specify octal mode for files and symlinks that will be copied.
+      # Since version 2016.11.0 it's possible to use 'keep' for file_mode,
+      # to preserve file original mode, thus you can save execution bit for example.
       file_mode: keep
-      # You can specify octal mode for directories as well. This won't work on Windows minions
+      # You can specify octal mode for directories as well.
+      # This won't work on Windows minions
       # dir_mode: 775
       sym_mode: 640
       exclude_pat: "*.gitignore"
 
   ## Absent user
   cuser:
-    absent: True
-    purge: True
-    force: True
+    absent: true
+    purge: true
+    force: true
 
 
 ## Old syntax of absent_users still supported

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: users formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -22,7 +22,8 @@ groups:
   ssl-cert:
     system: true
     members:
-      # *TODO*: run groups after all users created and then use `auser` and `buser` instead
+      # *TODO*: run groups after all users created and then use `auser` and
+      # `buser` instead
       - root
       - sshd
       # - bin
@@ -172,16 +173,18 @@ users:
 
     user_files:
       enabled: true
-      # 'source' allows you to define an arbitrary directory to sync, useful to use for default files.
+      # 'source' allows you to define an arbitrary directory to sync,
+      # useful to use for default files.
       # should be a salt fileserver path either with or without 'salt://'
       # if not present, it defaults to 'salt://users/files/user/<username>
       source: users/files
       # template: jinja
-      # You can specify octal mode for files and symlinks that will be copied. Since version 2016.11.0
-      # it's possible to use 'keep' for file_mode, to preserve file original mode, thus you can save
-      # execution bit for example.
+      # You can specify octal mode for files and symlinks that will be copied.
+      # Since version 2016.11.0 it's possible to use 'keep' for file_mode,
+      # to preserve file original mode, thus you can save execution bit for example.
       file_mode: keep
-      # You can specify octal mode for directories as well. This won't work on Windows minions
+      # You can specify octal mode for directories as well.
+      # This won't work on Windows minions
       # dir_mode: 775
       sym_mode: 640
       exclude_pat: "*.gitignore"

--- a/users/defaults.yaml
+++ b/users/defaults.yaml
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
-
+---
 users-formula:
-  use_vim_formula: False
+  use_vim_formula: false
 
 users:
-  allow_gid_change: True
-  createhome: True
-
+  allow_gid_change: true
+  createhome: true


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
users-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./users/defaults.yaml
  4:1       warning  missing document start "---"  (document-start)
  5:20      warning  truthy value should be one of [false, true]  (truthy)
  8:21      warning  truthy value should be one of [false, true]  (truthy)
  9:15      warning  truthy value should be one of [false, true]  (truthy)
  10:1      error    too many blank lines (1 > 0)  (empty-lines)

pillar.example
  5:20      warning  truthy value should be one of [false, true]  (truthy)
  14:13     warning  truthy value should be one of [false, true]  (truthy)
  16:13     warning  truthy value should be one of [false, true]  (truthy)
  19:13     warning  truthy value should be one of [false, true]  (truthy)
  23:13     warning  truthy value should be one of [false, true]  (truthy)
  25:5      error    wrong indentation: expected 6 but found 4  (indentation)
  37:23     warning  truthy value should be one of [false, true]  (truthy)
  40:21     warning  truthy value should be one of [false, true]  (truthy)
  41:20     warning  truthy value should be one of [false, true]  (truthy)
  42:13     warning  truthy value should be one of [false, true]  (truthy)
  47:17     warning  truthy value should be one of [false, true]  (truthy)
  51:19     warning  truthy value should be one of [false, true]  (truthy)
  52:23     warning  truthy value should be one of [false, true]  (truthy)
  53:20     warning  truthy value should be one of [false, true]  (truthy)
  54:21     warning  truthy value should be one of [false, true]  (truthy)
  58:15     warning  truthy value should be one of [false, true]  (truthy)
  59:15     warning  truthy value should be one of [false, true]  (truthy)
  73:18     warning  truthy value should be one of [false, true]  (truthy)
  75:20     warning  truthy value should be one of [false, true]  (truthy)
  90:7      error    duplication of key "privkey" in mapping  (key-duplicates)
  91:7      error    duplication of key "pubkey" in mapping  (key-duplicates)
  117:44    warning  too few spaces before comment  (comments)
  125:27    warning  truthy value should be one of [false, true]  (truthy)
  153:17    warning  truthy value should be one of [false, true]  (truthy)
  167:13    warning  truthy value should be one of [false, true]  (truthy)
  171:16    warning  truthy value should be one of [false, true]  (truthy)
  172:89    error    line too long (102 > 88 characters)  (line-length)
  177:89    error    line too long (102 > 88 characters)  (line-length)
  178:89    error    line too long (100 > 88 characters)  (line-length)
  181:89    error    line too long (94 > 88 characters)  (line-length)
  188:13    warning  truthy value should be one of [false, true]  (truthy)
  189:12    warning  truthy value should be one of [false, true]  (truthy)
  190:12    warning  truthy value should be one of [false, true]  (truthy)

test/salt/pillar/default.sls
  25:89     error    line too long (91 > 88 characters)  (line-length)
  175:89    error    line too long (102 > 88 characters)  (line-length)
  180:89    error    line too long (102 > 88 characters)  (line-length)
  181:89    error    line too long (100 > 88 characters)  (line-length)
  184:89    error    line too long (94 > 88 characters)  (line-length)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.